### PR TITLE
Add dark theme support with animated toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,17 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Import dark theme styles */
+@import "./theme-dark.css";
+
+:root {
+  /* Light theme variables */
+  --background: #ffffff;
+  --foreground: #1a1a1a;
+  --primary: #0072bc;
+  --secondary: #3f51b5;
+  --accent: #0054a6;
+  --border: #d1d5db;
+  --card-bg: #f9fafb;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,11 +11,13 @@ import { Pagination } from "@/builder-components";
 import { AreaChart } from "@/builder-components";
 import { BarChart } from "@/builder-components";
 import { Table } from "@/builder-components";
+import { ThemeProvider } from "@/components/ThemeContext/ThemeContext";
+import { ThemeToggle } from "@/components/ThemeToggle/ThemeToggle";
 
 export default function Home() {
   return (
-    <div>
-      <div className="bg-white">
+    <ThemeProvider>
+      <div className="bg-background">
         <TopNavigation
           className="bg-slate-900"
           identity={{
@@ -80,6 +82,7 @@ export default function Home() {
             },
           ]}
         />
+        <ThemeToggle />
         <AppLayout
           navigationOpen={false}
           navigation={
@@ -549,6 +552,6 @@ export default function Home() {
           </div>
         </AppLayout>
       </div>
-    </div>
+    </ThemeProvider>
   );
 }

--- a/app/theme-dark.css
+++ b/app/theme-dark.css
@@ -1,0 +1,105 @@
+/* Dark mode variables and Cloudscape overrides */
+.dark-theme {
+  /* Theme colors */
+  --background: #121212;
+  --foreground: #e0e0e0;
+  --primary: #4cc9f0;
+  --secondary: #4361ee;
+  --accent: #3a86ff;
+  --border: #303030;
+  --card-bg: #1e1e1e;
+}
+
+/* Override Cloudscape components for dark mode */
+.dark-theme .awsui_root_1yjtk_cee99_93 {
+  --color-background-container-content: #121212 !important;
+  --color-background-layout-main: #121212 !important;
+  --color-background-home-header: #242424 !important;
+  --color-text-body-default: #e0e0e0 !important;
+  --color-text-header-default: #f8f8f8 !important;
+  --color-background-dropdown-item-hover: #303030 !important;
+  --color-background-dropdown-item-selected: #383838 !important;
+  --color-border-divider-default: #303030 !important;
+  --color-border-control-default: #505050 !important;
+  --color-text-interactive-default: #4cc9f0 !important;
+  --color-text-link-default: #4cc9f0 !important;
+}
+
+/* Main app layout dark mode */
+.dark-theme main.awsui_layout_hyvsj_t18rz_388,
+.dark-theme div.awsui_content-first-child-main_hyvsj_t18rz_543 {
+  background-color: #121212 !important;
+  color: #e0e0e0 !important;
+}
+
+/* Top navigation dark mode */
+.dark-theme nav[class*="awsui_root"] {
+  background-color: #1a1a1a !important;
+  border-bottom: 1px solid #303030 !important;
+}
+
+/* Side navigation dark mode */
+.dark-theme div[class*="awsui_wrapper"],
+.dark-theme div[class*="awsui_tools-container"] {
+  background-color: #1a1a1a !important;
+  border-right: 1px solid #303030 !important;
+}
+
+/* Tables in dark mode */
+.dark-theme table[class*="awsui_root"],
+.dark-theme thead[class*="awsui_header"],
+.dark-theme tbody[class*="awsui_body"] {
+  background-color: #1e1e1e !important;
+  color: #e0e0e0 !important;
+  border-color: #303030 !important;
+}
+
+.dark-theme tr[class*="awsui_row"],
+.dark-theme td[class*="awsui_cell"] {
+  background-color: #1e1e1e !important;
+  color: #e0e0e0 !important;
+  border-color: #303030 !important;
+}
+
+/* Chart components dark mode */
+.dark-theme div[class*="awsui_root-container"],
+.dark-theme div[class*="awsui_chart-container"] {
+  background-color: #1e1e1e !important;
+  color: #e0e0e0 !important;
+}
+
+/* Button components dark mode */
+.dark-theme button[class*="awsui_button-variant-primary"] {
+  background-color: #4361ee !important;
+}
+
+.dark-theme button[class*="awsui_button-variant-normal"] {
+  background-color: #242424 !important;
+  color: #e0e0e0 !important;
+  border-color: #505050 !important;
+}
+
+/* Input components dark mode */
+.dark-theme input[class*="awsui_input"] {
+  background-color: #242424 !important;
+  color: #e0e0e0 !important;
+  border-color: #505050 !important;
+}
+
+/* Filter components dark mode */
+.dark-theme div[class*="awsui_root-filter"] {
+  background-color: #1e1e1e !important;
+  color: #e0e0e0 !important;
+}
+
+/* Breadcrumbs dark mode */
+.dark-theme div[class*="awsui_breadcrumb-group"] a {
+  color: #4cc9f0 !important;
+}
+
+/* Headers dark mode */
+.dark-theme h1[class*="awsui_heading"],
+.dark-theme h2[class*="awsui_heading"],
+.dark-theme h3[class*="awsui_heading"] {
+  color: #f0f0f0 !important;
+}

--- a/components/ThemeContext/ThemeContext.tsx
+++ b/components/ThemeContext/ThemeContext.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import React, {
+  createContext,
+  useState,
+  useEffect,
+  useContext,
+  ReactNode,
+} from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>("light");
+
+  useEffect(() => {
+    // Check if code is running in browser environment
+    if (typeof window !== "undefined") {
+      // Try to get stored theme from localStorage
+      const storedTheme = localStorage.getItem("theme") as Theme | null;
+
+      // Set theme from localStorage or use system preference as fallback
+      if (storedTheme) {
+        setTheme(storedTheme);
+      } else if (
+        window.matchMedia &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches
+      ) {
+        setTheme("dark");
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      // Apply theme class to html element for greater specificity
+      if (theme === "dark") {
+        document.documentElement.classList.add("dark-theme");
+      } else {
+        document.documentElement.classList.remove("dark-theme");
+      }
+    }
+
+    // Save theme preference to localStorage
+    if (typeof window !== "undefined") {
+      localStorage.setItem("theme", theme);
+    }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prevTheme) => (prevTheme === "light" ? "dark" : "light"));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = (): ThemeContextType => {
+  const context = useContext(ThemeContext);
+
+  if (context === undefined) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+
+  return context;
+};

--- a/components/ThemeToggle/ThemeToggle.tsx
+++ b/components/ThemeToggle/ThemeToggle.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { useTheme } from "../ThemeContext/ThemeContext";
+import styles from "./styles.module.css";
+
+interface ConfettiParticle {
+  id: number;
+  x: number;
+  y: number;
+  size: number;
+  color: string;
+  rotation: number;
+}
+
+export const ThemeToggle: React.FC = () => {
+  const { theme, toggleTheme } = useTheme();
+  const [confetti, setConfetti] = useState<ConfettiParticle[]>([]);
+
+  const handleToggle = () => {
+    toggleTheme();
+    generateConfetti();
+  };
+
+  const generateConfetti = () => {
+    const colors = ["#FFD700", "#FF6347", "#7FFFD4", "#9370DB", "#32CD32"];
+    const newConfetti: ConfettiParticle[] = [];
+
+    for (let i = 0; i < 30; i++) {
+      newConfetti.push({
+        id: i,
+        x: Math.random() * 100,
+        y: Math.random() * 20,
+        size: Math.random() * 8 + 2,
+        color: colors[Math.floor(Math.random() * colors.length)],
+        rotation: Math.random() * 360,
+      });
+    }
+
+    setConfetti(newConfetti);
+
+    // Clear confetti after animation finishes
+    setTimeout(() => {
+      setConfetti([]);
+    }, 3000);
+  };
+
+  useEffect(() => {
+    // Clean up confetti when component unmounts
+    return () => {
+      setConfetti([]);
+    };
+  }, []);
+
+  return (
+    <div className={styles.toggleContainer}>
+      <button
+        className={`${styles.toggleButton} ${theme === "dark" ? styles.dark : styles.light}`}
+        onClick={handleToggle}
+        aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
+      >
+        {theme === "light" ? (
+          <svg
+            className={styles.icon}
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="12" r="5"></circle>
+            <line x1="12" y1="1" x2="12" y2="3"></line>
+            <line x1="12" y1="21" x2="12" y2="23"></line>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+            <line x1="1" y1="12" x2="3" y2="12"></line>
+            <line x1="21" y1="12" x2="23" y2="12"></line>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+          </svg>
+        ) : (
+          <svg
+            className={styles.icon}
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+          </svg>
+        )}
+      </button>
+
+      {confetti.length > 0 && (
+        <div className={styles.confettiContainer} aria-hidden="true">
+          {confetti.map((particle) => (
+            <div
+              key={particle.id}
+              className={styles.confettiParticle}
+              style={{
+                left: `${particle.x}%`,
+                top: `${particle.y}%`,
+                width: `${particle.size}px`,
+                height: `${particle.size}px`,
+                backgroundColor: particle.color,
+                transform: `rotate(${particle.rotation}deg)`,
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/ThemeToggle/styles.module.css
+++ b/components/ThemeToggle/styles.module.css
@@ -1,0 +1,81 @@
+.toggleContainer {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  padding: 0.5rem 0;
+  background-color: transparent;
+  z-index: 10;
+  margin-bottom: 0.5rem;
+}
+
+.toggleButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background-color: var(--toggle-bg, #f0f0f0);
+  border: 2px solid var(--toggle-border, #e0e0e0);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  color: var(--toggle-icon, #333);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.toggleButton:hover {
+  transform: scale(1.05);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.15);
+}
+
+.toggleButton:active {
+  transform: scale(0.95);
+}
+
+.icon {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.light {
+  --toggle-bg: #f0f0f0;
+  --toggle-border: #e0e0e0;
+  --toggle-icon: #ffa41b;
+}
+
+.dark {
+  --toggle-bg: #2d3748;
+  --toggle-border: #4a5568;
+  --toggle-icon: #f0f0f0;
+}
+
+.confettiContainer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100px;
+  pointer-events: none;
+  z-index: 1000;
+  overflow: hidden;
+}
+
+.confettiParticle {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  animation: confettiFall 3s ease-out forwards;
+}
+
+@keyframes confettiFall {
+  0% {
+    transform: translateY(-10px) rotate(0deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(150px) rotate(720deg);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
Adds dark theme support to the application with:

- Theme context provider for managing theme state
- Animated theme toggle button with confetti effect
- Dark theme styles for Cloudscape components
- CSS variables for consistent theming
- System preference detection and localStorage persistence

The implementation includes proper TypeScript types and follows React best practices.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=nova-field&projectId=d0f8132a29a1410b9267068aff3d0fbe)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d0f8132a29a1410b9267068aff3d0fbe</projectId>-->